### PR TITLE
Remove middleware: connect.bodyParser()

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,11 +51,12 @@ MongoClient.connect(url,{
 	console.log(err);
 	process.exit(1);
     }
-    
+
     var express = require('express');
     var app = express();
 
-    app.use(express.bodyParser());
+    app.use(express.urlencoded());
+    app.use(express.json());
     app.use(express.cookieParser('boomerang-express'));
     app.use(express.logger());
     app.use(express.cookieSession());


### PR DESCRIPTION
Because `connect.bodyParser()` is deprecated and will be removed in Connect 3, this pull request removes it from the middleware stack and replaces it with `connect.urlencoded()` and `connect.json()`.

See [Connect 3.0 Wiki](https://github.com/senchalabs/connect/wiki/Connect-3.0) for more information.
